### PR TITLE
feat: Allowing the host_name used for HTTP requests to be configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,17 @@ DX::Api::Search.find_data_objects(
 )
 ```
 
+### Configuration
+
+If your DNAnexus endpoint is different from the default (`https://api.dnanexus.com`), you can override its value like this:
+
+```ruby
+# config/initializers/dx_api.rb
+
+# Default: https://api.dnanexus.com
+DX::Api.host_name = "https://custom-api.dnanexus.com"
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/dx/api.rb
+++ b/lib/dx/api.rb
@@ -15,7 +15,19 @@ require 'dx/api/version'
 
 module DX
   module Api
-    HOST_NAME = 'https://api.dnanexus.com'
+    # Sets the host name used for API calls
+    #
+    # @param value [String] The API host
+    def self.host_name=(value)
+      @host_name = value
+    end
+
+    # Returns the host name used for API calls.
+    #
+    # Default: https://api.dnanexus.com
+    def self.host_name
+      @host_name || "https://api.dnanexus.com"
+    end
 
     class Error < StandardError; end
 

--- a/lib/dx/api/request.rb
+++ b/lib/dx/api/request.rb
@@ -8,8 +8,6 @@ module DX
   module Api
     # A helper class to create and make http requests to the DNAnexus API
     class Request
-      HOST_NAME = 'https://api.dnanexus.com'
-
       extend Forwardable
 
       attr_reader :api_token,
@@ -25,7 +23,7 @@ module DX
       # @param body [Hash] The request payload
       def initialize(api_token:, path:, body: {})
         @api_token = api_token
-        @uri = URI([HOST_NAME, path].join('/'))
+        @uri = URI([DX::Api.host_name, path].join('/'))
         @body = body.to_json
       end
 

--- a/spec/dx/api/request_spec.rb
+++ b/spec/dx/api/request_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe DX::Api::Request do
+  let(:api_token) { "" }
+  let(:path) { "" }
+
+  describe "#uri" do
+    after { DX::Api.host_name = nil }
+
+    it "uses the configurable DX::Api.host_name as it's base host" do
+      expect { DX::Api.host_name = "https://example.com" }.to change { DX::Api::Request.new(api_token: api_token, path: path).uri }
+        .from(URI("https://api.dnanexus.com/")).to(URI("https://example.com/"))
+    end
+  end
+end

--- a/spec/dx/api_spec.rb
+++ b/spec/dx/api_spec.rb
@@ -1,7 +1,22 @@
 # frozen_string_literal: true
 
 RSpec.describe DX::Api do
-  it 'has a version number' do
+  it "has a version number" do
     expect(DX::Api::VERSION).not_to be nil
+  end
+
+  describe "::host_name" do
+    after { DX::Api.host_name = nil }
+
+    it "can be overwritten" do
+      expect { DX::Api.host_name = "https://example.com" }.to change(DX::Api, :host_name)
+        .from("https://api.dnanexus.com").to("https://example.com")
+    end
+
+    it "resets to the default value when set to nil" do
+      DX::Api.host_name = "https://example.com"
+      expect { DX::Api.host_name = nil }.to change(DX::Api, :host_name)
+        .from("https://example.com").to("https://api.dnanexus.com")
+    end
   end
 end


### PR DESCRIPTION
DNAnexus has a staging environment which (and I think a few others) which are useful to be able to touch when making requests from non-production enviroments :)

This adds support for `DX::Api.host_name="https://example.com/"`, which can be added to an initializes in a Rails apps.